### PR TITLE
fix: Issue when running under Pub Workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.4
+
+- Fixed issue when using Pub Workspaces.
+
 ## 0.3.3
 
 - Transfer ownership

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:build/build.dart';
@@ -20,15 +19,6 @@ class TailwindBuilder implements Builder {
     await scratchSpace.ensureAssets({buildStep.inputId}, buildStep);
 
     var outputId = buildStep.inputId.changeExtension('').changeExtension('.css');
-
-    var packageFile = File('.dart_tool/package_config.json');
-    var packageJson = jsonDecode(await packageFile.readAsString());
-
-    var packageConfig = (packageJson['packages'] as List?)?.where((p) => p['name'] == 'jaspr_tailwind').firstOrNull;
-    if (packageConfig == null) {
-      print("Cannot find 'jaspr_tailwind' in package config.");
-      return;
-    }
 
     // in order to rebuild when source files change
     var assets = await buildStep.findAssets(Glob('{lib,web}/**.dart')).toList();


### PR DESCRIPTION
## Issue 

- When running `jaspr serve/build` with the `jaspr_tailwind` package in a Pub Workspaces environment, the command throws a `PathNotFoundException`.
  - This issue occurs because Pub Workspaces do not generate the `.dart_tool/package_config.json` file.

## Fix

- Remove the check for the `.dart_tool/package_config.json` file.
- Add version `v0.3.4` to the CHANGELOG.md file.

## Screenshot

|Before|After|
|---|---|
|||
