### PR TITLE
Moving imports from build_modules to build_web_compilers

### DIFF
--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 import 'dart:isolate';
 
 import 'package:build/build.dart';
-import 'package:build_modules/build_modules.dart';
+import 'package:build_web_compilers/build_web_compilers.dart';
 import 'package:glob/glob.dart';
 import 'package:path/path.dart' as p;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
 
 dependencies:
   build: ^4.0.0
-  build_modules: ^5.0.4
+  build_web_compilers: ^4.0.0
   glob: ^2.1.2
   path: ^1.8.3
 


### PR DESCRIPTION
`build_modules` was moved into `build_web_compilers` in `4.5.0`. 

Fixes issues like: https://github.com/dart-lang/build/issues/4963